### PR TITLE
issue #5 アプリをサスペンドした時に落ちるバグを修正

### DIFF
--- a/GitHub_Explorer/DataModel/IssueCommentDataSource.cs
+++ b/GitHub_Explorer/DataModel/IssueCommentDataSource.cs
@@ -12,11 +12,6 @@ using Octokit.Helpers;
 using Octokit.Internal;
 using Octokit.Reflection;
 using GitHub_Explorer.Service;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GitHub_Explorer.Data
 {

--- a/GitHub_Explorer/GitHub_Explorer.csproj
+++ b/GitHub_Explorer/GitHub_Explorer.csproj
@@ -158,6 +158,9 @@
     <Content Include="DataModel\SampleData.json" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="Octokit">
       <HintPath>..\packages\Octokit.0.7.2\lib\portable-net45+wp80+win+wpa81\Octokit.dll</HintPath>
     </Reference>

--- a/GitHub_Explorer/IssueInfoPage.xaml.cs
+++ b/GitHub_Explorer/IssueInfoPage.xaml.cs
@@ -29,6 +29,7 @@ using Octokit.Reflection;
 using GitHub_Explorer.Service;
 using GitHub_Explorer.NavigationParam;
 using Windows.System.Threading;
+using Newtonsoft.Json;
 
 // 空白ページのアイテム テンプレートについては、http://go.microsoft.com/fwlink/?LinkID=390556 を参照してください
 
@@ -106,8 +107,9 @@ namespace GitHub_Explorer
         /// このプロパティは、通常、ページを構成するために使用します。</param>
         protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
-            naviParam = e.Parameter as IssueInfoNaviParam;
             this.navigationHelper.OnNavigatedTo(e);
+            string jsonParam = e.Parameter as string;
+            naviParam = JsonConvert.DeserializeObject<IssueInfoNaviParam>(jsonParam);
             await LoadIssueInfo(naviParam.Owner, naviParam.Name, naviParam.Number);
         }
 

--- a/GitHub_Explorer/RepositoryInfoPage.xaml.cs
+++ b/GitHub_Explorer/RepositoryInfoPage.xaml.cs
@@ -29,6 +29,7 @@ using Octokit.Reflection;
 using GitHub_Explorer.Service;
 using GitHub_Explorer.NavigationParam;
 using Windows.System.Threading;
+using Newtonsoft.Json;
 
 // 空白ページのアイテム テンプレートについては、http://go.microsoft.com/fwlink/?LinkID=390556 を参照してください
 
@@ -87,9 +88,6 @@ namespace GitHub_Explorer
         /// イベント データ。ページに初めてアクセスするとき、状態は null になります。</param>
         private async void NavigationHelper_LoadState(object sender, LoadStateEventArgs e)
         {
-            naviParam = e.NavigationParameter as RepositoryInfoNaviParam;
-            pivot.Title = naviParam.Name;
-            await LoadRepositoryInfo(naviParam.Owner, naviParam.Name);
         }
 
         /// <summary>
@@ -113,7 +111,8 @@ namespace GitHub_Explorer
         protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             this.navigationHelper.OnNavigatedTo(e);
-            naviParam = e.Parameter as RepositoryInfoNaviParam;
+            string jsonParam = e.Parameter as string;
+            naviParam = JsonConvert.DeserializeObject<RepositoryInfoNaviParam>(jsonParam);
             pivot.Title = naviParam.Name;
             await LoadRepositoryInfo(naviParam.Owner, naviParam.Name);
         }
@@ -140,8 +139,10 @@ namespace GitHub_Explorer
         {
             // 適切な移動先のページに移動し、新しいページを構成します。
             // このとき、必要な情報をナビゲーション パラメーターとして渡します
-            IssueInfoNaviParam param = new IssueInfoNaviParam(naviParam.Owner, naviParam.Name, ((IssueDataItem)e.ClickedItem).Number);
-            if (!Frame.Navigate(typeof(IssueInfoPage), param))
+            IssueInfoNaviParam objectParam = new IssueInfoNaviParam(naviParam.Owner, naviParam.Name, ((IssueDataItem)e.ClickedItem).Number);
+            string jsonParam = JsonConvert.SerializeObject(objectParam);
+
+            if (!Frame.Navigate(typeof(IssueInfoPage), jsonParam))
             {
                 throw new Exception(this.resourceLoader.GetString("NavigationFailedExceptionMessage"));
             }

--- a/GitHub_Explorer/TopMenuPivotPage.xaml
+++ b/GitHub_Explorer/TopMenuPivotPage.xaml
@@ -102,7 +102,6 @@
             <AppBarButton x:Uid="UpdateAppBarButton" x:Name="UpdateButton1" Label="Update" Icon="Sync" Click="Update_Click"/>
             <CommandBar.SecondaryCommands>
                 <AppBarButton x:Uid="SecondaryButton1" x:Name="SignInButton" Label="SignIn button" Click="SignIn_Click"/>
-                <AppBarButton x:Uid="Test1" x:Name="TestButton" Label="Test button" Click="Test_Click"/>
             </CommandBar.SecondaryCommands>
         </CommandBar>
     </Page.BottomAppBar>

--- a/GitHub_Explorer/TopMenuPivotPage.xaml.cs
+++ b/GitHub_Explorer/TopMenuPivotPage.xaml.cs
@@ -27,6 +27,7 @@ using Octokit.Internal;
 using Octokit.Reflection;
 using GitHub_Explorer.Service;
 using GitHub_Explorer.NavigationParam;
+using Newtonsoft.Json;
 
 // ピボット アプリケーション テンプレートについては、http://go.microsoft.com/fwlink/?LinkID=391641 を参照してください
 
@@ -141,10 +142,10 @@ namespace GitHub_Explorer
         {
             // 適切な移動先のページに移動し、新しいページを構成します。
             // このとき、必要な情報をナビゲーション パラメーターとして渡します
-            RepositoryInfoNaviParam param = new RepositoryInfoNaviParam(((RepositoryListDataItem)e.ClickedItem).OwnerName,
+            RepositoryInfoNaviParam objectParam = new RepositoryInfoNaviParam(((RepositoryListDataItem)e.ClickedItem).OwnerName,
                                                                         ((RepositoryListDataItem)e.ClickedItem).Name);
-            //            Frame.Navigate(typeof(LoginContentDialog));
-            if (!Frame.Navigate(typeof(RepositoryInfoPage), param))
+            string jsonParam = JsonConvert.SerializeObject(objectParam);
+            if (!Frame.Navigate(typeof(RepositoryInfoPage), jsonParam))
             {
                 throw new Exception(this.resourceLoader.GetString("NavigationFailedExceptionMessage"));
             }
@@ -224,18 +225,6 @@ namespace GitHub_Explorer
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
             this.navigationHelper.OnNavigatedFrom(e);
-        }
-
-        private async void Test_Click(object sender, RoutedEventArgs e)
-        {
-            // 適切な移動先のページに移動し、新しいページを構成します。
-            // このとき、必要な情報をナビゲーション パラメーターとして渡します
-            var param = 12;
-            //            Frame.Navigate(typeof(LoginContentDialog));
-            if (!Frame.Navigate(typeof(ItemPage), param))
-            {
-                throw new Exception(this.resourceLoader.GetString("NavigationFailedExceptionMessage"));
-            }
         }
 
         #endregion

--- a/GitHub_Explorer/packages.config
+++ b/GitHub_Explorer/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="wpa81" />
   <package id="Octokit" version="0.7.2" targetFramework="wpa81" />
 </packages>


### PR DESCRIPTION
Frame.Navigete()の第二引数に基本型以外を使用すると
サスペンド時に落ちるバグをjsonを使用する形に修正